### PR TITLE
pkg/cluster: add support for custom pull-secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # dev-installer
 tooling for creating and managing OCP 4 clusters
 
+
+#### CI images require you to be logged in to ci via `oc login`
+
 ```bash
 bin/dev-installer cluster \
   -p aws \
@@ -9,3 +12,15 @@ bin/dev-installer cluster \
   -s ~/.ssh/libra.pub \
   -n cluster-test 
 ```
+
+#### Custom pull-secret
+
+```bash
+./bin/dev-installer cluster \
+  -p aws \
+  -r docker.io/hexfusion/origin-release:v4.4 \
+  -t custom \
+  -s ~/.ssh/libra.pub \
+  --pull-secret=/home/remote/sbatsche/.PULL_SECRET_BUILD \
+  -n test-cluster
+  ```

--- a/pkg/cluster/config/config.go
+++ b/pkg/cluster/config/config.go
@@ -4,10 +4,11 @@ type Auth struct {
 	Auth  string `yaml:"auth"`
 	Email string `yaml:"email"`
 	Name  string `yaml:"name"`
+	Registry string `yaml:"registry"`
 }
 
-type Config struct {
-	BaseDir `yaml:"base_dir"`
-	SSHPath `yaml:"ssh_path"`
+type File struct {
+	BaseDir string `yaml:"basedir"`
+	SSHPath string `yaml:"sshpath"`
 	Tokens  []Auth `yaml:"tokens"`
 }


### PR DESCRIPTION
This PR adds support for a custom pull-secret to be passed.

```
./bin/dev-installer cluster \
  -p aws \
  -r docker.io/hexfusion/origin-release:v4.4 \
  -t custom \
  -s /home/remote/sbatsche/.ssh/libra.pub \
  --pull-secret=/home/remote/sbatsche/.PULL_SECRET_BUILD \
  -n test-ceo
```

I also added the initial structs and functions for a global config file this is still WIP