### PR TITLE
pkg/cluster add libvirt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # dev-installer
 tooling for creating and managing OCP 4 clusters
 
-
 #### CI images require you to be logged in to ci via `oc login`
 
 ```bash
@@ -22,5 +21,18 @@ bin/dev-installer cluster \
   -t custom \
   -s ~/.ssh/libra.pub \
   --pull-secret=/home/remote/sbatsche/.PULL_SECRET_BUILD \
+  -n test-cluster
+  ```
+
+#### libvirt requires a precompiled installer with libvirt support
+
+```bash
+./bin/dev-installer cluster \
+  -p libvirt \
+  -r docker.io/hexfusion/origin-release:v4.4 \
+  -t custom \
+  -s ~/.ssh/libra.pub \
+  --pull-secret=/home/remote/sbatsche/.PULL_SECRET_BUILD \
+  --installer-path=/home/remote/sbatsche/projects/openshift/installer/bin/openshift-install \
   -n test-cluster
   ```

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -372,6 +372,16 @@ func (c *Cluster) writeInstallConfig() error {
 
 func (c *Cluster) runInstaller() error {
 	installerPath := fmt.Sprintf("%s/%s", c.Dir, "bin/openshift-install")
+	if c.opts.installerPath != "" {
+		if err := os.Remove(installerPath); err != nil {
+			return err
+		}
+		err := os.Symlink(c.opts.installerPath, installerPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	args := []string{"create", "cluster", "--dir", c.Dir, "--log-level", c.LogLevel}
 
 	cmd := exec.Command(installerPath, args...)

--- a/templates/installer/libvirt/install-config.yaml
+++ b/templates/installer/libvirt/install-config.yaml
@@ -4,12 +4,12 @@ compute:
   - hyperthreading: Enabled
     name: worker
     platform: {}
-    replicas: {{ .WorkerReplicas }}
+    replicas: 1
 controlPlane:
   hyperthreading: Enabled
   name: master
   platform: {}
-  replicas: {{ .MasterReplicas }}
+  replicas: 1
 metadata:
   creationTimestamp: null
   name: {{ .ClusterName }}


### PR DESCRIPTION
This PR adds support and examples for libvirt. We are going to stick with the hardcoded single master and worker for now.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>