### PR TITLE
Making name optional 

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -123,9 +123,6 @@ func (c *clusterOpts) Validate() error {
 	if len(c.sshKeyPath) == 0 {
 		return errors.New("missing required flag: --ssh-path -s")
 	}
-	if len(c.name) == 0 {
-		return errors.New("missing required flag: --name -n")
-	}
 	return nil
 }
 
@@ -188,6 +185,10 @@ func newCluster(opts *clusterOpts) (*Cluster, error) {
 	//if err != nil {
 	//	return nil, err
 	//}
+
+	if opts.name == "" {
+		opts.name = t.Format("0102150405")
+	}
 
 	clusterName := fmt.Sprintf("%s-%s-%s", user.Username, opts.name, date)
 	sshKey, err := ioutil.ReadFile(opts.sshKeyPath)
@@ -620,7 +621,6 @@ func (c *Cluster) runInstaller() error {
 	}()
 
 	stderr, errStderr = copyAndCapture(os.Stderr, stderrIn)
-
 	wg.Wait()
 
 	err = cmd.Wait()

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"os"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -14,7 +15,7 @@ auths:
      email: ""
      auth: "example"
 ssh:
-   - publicKeyPath: "/home/remote/sbatsche/.ssh/libra.pub"
+   - publicKeyPath: "` + os.UserHomeDir() + `/.ssh/libra.pub"
 `
 )
 
@@ -48,7 +49,7 @@ func testCluster(tc *testConfig) {
 		releaseImageType: "ci",
 		baseDir: clusterDir,
 		errOut:           errOut,
-		sshKeyPath:       "/home/remote/sbatsche/.ssh/libra.pub",
+		sshKeyPath:       os.UserHomeDir() + "/.ssh/libra.pub",
 	}
 
 	cluster, err := newCluster(clusterOpts)


### PR DESCRIPTION
Two changes:
1. Made `-n name` flag optional 
2. Added a daemon mode (-d flag) where Stdout and Stderr are redirected to a file in the install dir.