### PR TITLE
*: add support for azure IPv6 and defining install-config replicas

### DIFF
--- a/templates/installer/aws/install-config.yaml
+++ b/templates/installer/aws/install-config.yaml
@@ -4,12 +4,12 @@ compute:
 - hyperthreading: Enabled
   name: worker
   platform: {}
-  replicas: 3
+  replicas: {{ .WorkerReplicas }}
 controlPlane:
   hyperthreading: Enabled
   name: master
   platform: {}
-  replicas: 3
+  replicas: {{ .MasterReplicas }}
 metadata:
   creationTimestamp: null
   name: {{ .ClusterName }}

--- a/templates/installer/azure/install-config.yaml
+++ b/templates/installer/azure/install-config.yaml
@@ -4,23 +4,24 @@ compute:
 - hyperthreading: Enabled
   name: worker
   platform: {}
-  replicas: 3
+  replicas: {{ .WorkerReplicas }}
 controlPlane:
   hyperthreading: Enabled
   name: master
   platform: {}
-  replicas: 3
+  replicas: {{ .MasterReplicas }}
 metadata:
   creationTimestamp: null
   name: {{ .ClusterName }}
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
-  networkType: OpenShiftSDN
+  - cidr: {{ .ClusterCidr }}
+    hostPrefix: {{ .ClusterCidrHostPrefix }}
+  machineNetwork: {{range .MachineCidr}}
+  - cidr: {{.}}{{end}}
+  networkType: {{ .NetworkType }}
   serviceNetwork:
-  - 172.30.0.0/16
+  - {{ .ServiceCidr }}
 platform:
   azure:
     baseDomainResourceGroupName: os4-common

--- a/templates/installer/gcp/install-config.yaml
+++ b/templates/installer/gcp/install-config.yaml
@@ -4,12 +4,12 @@ compute:
 - hyperthreading: Enabled
   name: worker
   platform: {}
-  replicas: 3
+  replicas: {{ .WorkerReplicas }}
 controlPlane:
   hyperthreading: Enabled
   name: master
   platform: {}
-  replicas: 3
+  replicas: {{ .MasterReplicas }}
 metadata:
   creationTimestamp: null
   name: {{ .ClusterName }}

--- a/templates/installer/libvirt/install-config.yaml
+++ b/templates/installer/libvirt/install-config.yaml
@@ -4,12 +4,12 @@ compute:
   - hyperthreading: Enabled
     name: worker
     platform: {}
-    replicas: 1
+    replicas: {{ .WorkerReplicas }}
 controlPlane:
   hyperthreading: Enabled
   name: master
   platform: {}
-  replicas: 1
+  replicas: {{ .MasterReplicas }}
 metadata:
   creationTimestamp: null
   name: {{ .ClusterName }}
@@ -23,7 +23,7 @@ networking:
     - 172.30.0.0/16
 platform:
   libvirt:
-    URI: qemu+tcp://192.168.122.1/system
+    URI: {{ .LibvirtURI }}
     network:
       if: tt0
 pullSecret: '{{ .PullSecret }}'


### PR DESCRIPTION
This PR adds the following flags
```
--single-stack-ipv6
--replicas-master
--replicas-worker
--libvirt-uri
```